### PR TITLE
Add driver.Valuer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ Produces
 int:1 string:'2' []int:3,3 []string:'4','4' Query:5 JsonMap:'{"6":6}' nil:NULL []intf:'a',1,true
 ```
 
+## driver.Valuer
+
+The [driver.Valuer](https://pkg.go.dev/database/sql/driver#Valuer) interface is supported for types that are able to convert
+themselves to a sql driver value.
+
+```
+q := bqb.New("?", valuer)
+```
+
 ## Query IN
 
 Arguments of type `[]string`,`[]*string`, `[]int`,`[]*int`, or `[]interface{}` are automatically expanded.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/nullism/bqb
 
-go 1.19
+go 1.20

--- a/query.go
+++ b/query.go
@@ -10,6 +10,7 @@ import (
 type QueryPart struct {
 	Text   string
 	Params []interface{}
+	Errs   []error
 }
 
 // Query contains all the QueryParts for the query and is the primary
@@ -167,6 +168,10 @@ func (q *Query) toSql() (string, []interface{}, error) {
 	for _, p := range q.Parts {
 		sql += p.Text
 		params = append(params, p.Params...)
+
+		if len(p.Errs) != 0 {
+			return "", nil, errors.Join(p.Errs...)
+		}
 	}
 
 	return strings.TrimSpace(sql), params, nil


### PR DESCRIPTION
Adds support for the `driver.Valuer` interface for types that are able to convert themselves to a sql driver valuer.

Upgrades to Go 1.20 to access `errors.Join`