### PR TITLE
Add support for parametrizing/quoting identifiers(col/table names)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,29 @@ INSERT INTO my_table (json_map, json_list)
 VALUES ('{"a": 1, "b": ["a","b","c"]}', '["string",1,true,null]')
 ```
 
+## Identifiers
+
+In order to facilitate parametrizing table and column names, there is an `Identifier` helper type.
+
+```golang
+sql, err := bqb.New(
+    "INSERT INTO ? t (?) VALUES (?)",
+    bqb.Identifiers{"schema", "table"},
+    bqb.Identifiers{"t", "col with spaces and \" even"},
+    1,
+).ToSql()
+```
+
+Produces
+
+```sql
+INSERT INTO "schema"."table" t ("t"."col with spaces and "" even") VALUES (?)
+```
+
+```
+PARAMS: [1]
+```
+
 ## Query Building
 
 Since queries are built in an additive way by reference rather than value, it's easy to mutate a query without

--- a/query.go
+++ b/query.go
@@ -117,7 +117,7 @@ func (q *Query) ToMysql() (string, []interface{}, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	sql, err = dialectReplace(MYSQL, sql, params)
+	sql, params, err = dialectReplace(MYSQL, sql, params)
 	return sql, params, err
 }
 
@@ -127,7 +127,7 @@ func (q *Query) ToPgsql() (string, []interface{}, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	sql, err = dialectReplace(PGSQL, sql, params)
+	sql, params, err = dialectReplace(PGSQL, sql, params)
 	return sql, params, err
 }
 
@@ -139,7 +139,7 @@ func (q *Query) ToRaw() (string, error) {
 		return "", err
 	}
 
-	sql, err = dialectReplace(RAW, sql, params)
+	sql, _, err = dialectReplace(RAW, sql, params)
 	return sql, err
 }
 
@@ -150,7 +150,7 @@ func (q *Query) ToSql() (string, []interface{}, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	sql, err = dialectReplace(SQL, sql, params)
+	sql, params, err = dialectReplace(SQL, sql, params)
 	return sql, params, err
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -644,3 +644,41 @@ func TestIdentifiers(t *testing.T) {
 		t.Errorf("got incorrect param count: %v", len(params))
 	}
 }
+
+func TestIdentifiersPg(t *testing.T) {
+	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"},  Identifiers{"t", `b"ar`}, Identifiers{"table"})
+
+	sql, params, err := q.ToPgsql()
+
+	if err != nil {
+		t.Errorf("got error %v", err)
+	}
+
+	want := `SELECT "t"."foo", "t"."b""ar" FROM "table" AS t`
+	if sql != want {
+		t.Errorf("got: %q, want: %q", sql, want)
+	}
+
+	if len(params) != 0 {
+		t.Errorf("got incorrect param count: %v", len(params))
+	}
+}
+
+func TestIdentifiersMysql(t *testing.T) {
+	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"},  Identifiers{"t", `b"ar`}, Identifiers{"table"})
+
+	sql, params, err := q.ToMysql()
+
+	if err != nil {
+		t.Errorf("got error %v", err)
+	}
+
+	want := "SELECT `t`.`foo`, `t`.`b``ar` FROM `table` AS t"
+	if sql != want {
+		t.Errorf("got: %q, want: %q", sql, want)
+	}
+
+	if len(params) != 0 {
+		t.Errorf("got incorrect param count: %v", len(params))
+	}
+}

--- a/query_test.go
+++ b/query_test.go
@@ -625,3 +625,22 @@ func TestValuerError(t *testing.T) {
 		t.Errorf("got: %q, want: %q", err, wantError)
 	}
 }
+
+func TestIdentifiers(t *testing.T) {
+	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"},  Identifiers{"t", `b"ar`}, Identifiers{"table"})
+
+	sql, params, err := q.ToSql()
+
+	if err != nil {
+		t.Errorf("got error %v", err)
+	}
+
+	want := `SELECT "t"."foo", "t"."b""ar" FROM "table" AS t`
+	if sql != want {
+		t.Errorf("got: %q, want: %q", sql, want)
+	}
+
+	if len(params) != 0 {
+		t.Errorf("got incorrect param count: %v", len(params))
+	}
+}

--- a/query_test.go
+++ b/query_test.go
@@ -627,7 +627,7 @@ func TestValuerError(t *testing.T) {
 }
 
 func TestIdentifiers(t *testing.T) {
-	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"},  Identifiers{"t", `b"ar`}, Identifiers{"table"})
+	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"}, Identifiers{"t", `b"ar`}, Identifiers{"table"})
 
 	sql, params, err := q.ToSql()
 
@@ -646,7 +646,7 @@ func TestIdentifiers(t *testing.T) {
 }
 
 func TestIdentifiersPg(t *testing.T) {
-	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"},  Identifiers{"t", `b"ar`}, Identifiers{"table"})
+	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"}, Identifiers{"t", `b"ar`}, Identifiers{"table"})
 
 	sql, params, err := q.ToPgsql()
 
@@ -665,7 +665,7 @@ func TestIdentifiersPg(t *testing.T) {
 }
 
 func TestIdentifiersMysql(t *testing.T) {
-	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"},  Identifiers{"t", `b"ar`}, Identifiers{"table"})
+	q := New("SELECT ?, ? FROM ? AS t", Identifiers{"t", "foo"}, Identifiers{"t", "b`ar"}, Identifiers{"table"})
 
 	sql, params, err := q.ToMysql()
 


### PR DESCRIPTION
In order to facilitate parametrizing table and column names, this PR adds an `Identifier` type. Example:

```golang
sql, err := bqb.New(
    "INSERT INTO ? t (?) VALUES (?)",
    bqb.Identifiers{"schema", "table"},
    bqb.Identifiers{"t", "col with spaces and \" even"},
    1,
).ToSql()
```

Produces

```sql
INSERT INTO "schema"."table" t ("t"."col with spaces and "" even") VALUES (?)
```

```
PARAMS: [1]
```



Quoting logic pretty much just cribbed from here: https://github.com/lib/pq/blob/2a217b94f5ccd3de31aec4152a541b9ff64bed05/conn.go#LL1661C9-L1661C57