### PR TITLE
Forward errors from nested query

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -119,6 +119,25 @@ func TestJsonPointer(t *testing.T) {
 
 }
 
+func TestErrorSubquery(t *testing.T) {
+	// One more ? than we are passing args for
+	subQuery := New("SELECT id FROM table2 WHERE id = ? and value = ?", 1)
+
+	// It gives an error when the query is directly turned to sql
+	_, _, err := subQuery.ToSql()
+	if err == nil || !strings.Contains(err.Error(), "extra ? in text") {
+		t.Errorf("expected error for subquery")
+	}
+
+	// But if you pass it into another query instead there is no error and the sql it spits out will be
+	// "SELECT * FROM table WHERE id IN ()" which is not what I would expect
+	q := New("SELECT * FROM table WHERE id IN (?)", subQuery)
+	_, _, err = q.ToSql()
+	if err == nil || !strings.Contains(err.Error(), "extra ? in text") {
+		t.Errorf("expected error for subquery")
+	}
+}
+
 func TestOptional(t *testing.T) {
 	sel := Optional("you should not see this")
 

--- a/utils.go
+++ b/utils.go
@@ -99,9 +99,13 @@ func convertArg(text string, arg any) (string, []any, []error) {
 			newArgs = append(newArgs, nil)
 			return text, newArgs, errs
 		}
-		sql, params, _ := v.toSql()
+		sql, params, err := v.toSql()
 		text = strings.Replace(text, "?", sql, 1)
-		newArgs = append(newArgs, params...)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			newArgs = append(newArgs, params...)
+		}
 
 	case JsonMap, JsonList:
 		text = strings.Replace(text, "?", paramPh, 1)


### PR DESCRIPTION
Based on the code nearby it just seems like an accidental omission that the errors are not carried forward for `*Query` when constructing a new `Query`.

Fixes #22 