### PR TITLE
Use Scanning Replace for Parameter Tokenization

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -669,3 +669,23 @@ func TestValuerError(t *testing.T) {
 		t.Errorf("got: %q, want: %q", err, wantError)
 	}
 }
+
+func Benchmark_ToPgsql_Params(b *testing.B) {
+	parts := []string{}
+	args := []any{}
+	for j := 0; j < 10; j++ {
+		for j := 0; j < 1000; j++ {
+			parts = append(parts, "?")
+			args = append(args, 1)
+		}
+	}
+
+	query := fmt.Sprintf("(%s)", strings.Join(parts, ","))
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := New(query, args...).ToPgsql()
+		if err != nil {
+			b.Fatalf("failed to make benchmark sql: %v", err)
+		}
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,138 @@
+package bqb
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_scanReplace(t *testing.T) {
+	const (
+		testReplace = "{{TEST_TOKEN}}"
+	)
+	type args struct {
+		stmt    string
+		replace string
+		fn      replaceFn
+	}
+	type want struct {
+		str string
+		err error
+	}
+
+	for _, tt := range []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "empty statement",
+			args: args{
+				stmt:    "",
+				replace: testReplace,
+				fn: func(i int) string {
+					return fmt.Sprintf("%v", i)
+				},
+			},
+			want: want{
+				str: "",
+				err: nil,
+			},
+		},
+		{
+			name: "empty token statement",
+			args: args{
+				stmt:    "this tests an empty pattern token",
+				replace: "",
+				fn: func(i int) string {
+					return fmt.Sprintf("%v", i)
+				},
+			},
+			want: want{
+				str: "this tests an empty pattern token",
+				err: nil,
+			},
+		},
+		{
+			name: "no tokens",
+			args: args{
+				stmt:    "this tests no tokens",
+				replace: testReplace,
+				fn: func(i int) string {
+					return fmt.Sprintf("%v", i)
+				},
+			},
+			want: want{
+				str: "this tests no tokens",
+				err: nil,
+			},
+		},
+		{
+			name: "one front token",
+			args: args{
+				stmt:    fmt.Sprintf("%s this tests one token", testReplace),
+				replace: testReplace,
+				fn: func(i int) string {
+					return fmt.Sprintf("%v", i)
+				},
+			},
+			want: want{
+				str: "0 this tests one token",
+				err: nil,
+			},
+		},
+		{
+			name: "one boundary token",
+			args: args{
+				stmt:    fmt.Sprintf("this tests one%s token", testReplace),
+				replace: testReplace,
+				fn: func(i int) string {
+					return fmt.Sprintf("%v", i)
+				},
+			},
+			want: want{
+				str: "this tests one0 token",
+				err: nil,
+			},
+		},
+		{
+			name: "one end token",
+			args: args{
+				stmt:    fmt.Sprintf("this tests one token%s", testReplace),
+				replace: testReplace,
+				fn: func(i int) string {
+					return fmt.Sprintf("%v", i)
+				},
+			},
+			want: want{
+				str: "this tests one token0",
+				err: nil,
+			},
+		},
+		{
+			name: "several tokens",
+			args: args{
+				stmt:    fmt.Sprintf("this tests %s the token %s", testReplace, testReplace),
+				replace: testReplace,
+				fn: func(i int) string {
+					return fmt.Sprintf("%v", i)
+				},
+			},
+			want: want{
+				str: "this tests 0 the token 1",
+				err: nil,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			str, err := scanReplace(tt.args.stmt, testReplace, tt.args.fn)
+			if tt.want.str != str {
+				t.Errorf("unexpected str: want '%s' got '%s'", tt.want.str, str)
+			}
+
+			if tt.want.err != err {
+				t.Errorf("unexpected err: want '%s' got '%s'", tt.want.err, err)
+			}
+
+		})
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -122,6 +122,20 @@ func Test_scanReplace(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "several tokens",
+			args: args{
+				stmt:    fmt.Sprintf("%s%sthis tests %s%s the token %s%s", testReplace, testReplace, testReplace, testReplace, testReplace, testReplace),
+				replace: testReplace,
+				fn: func(i int) string {
+					return fmt.Sprintf("%v", i)
+				},
+			},
+			want: want{
+				str: "01this tests 23 the token 45",
+				err: nil,
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			str, err := scanReplace(tt.args.stmt, testReplace, tt.args.fn)
@@ -134,5 +148,21 @@ func Test_scanReplace(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func Test_dialectReplace_unknown_dialect(t *testing.T) {
+	const (
+		testSql = "test-sql"
+	)
+	params := []any{1, 2, "a", "c"}
+	sql, err := dialectReplace(Dialect("unknown"), testSql, params)
+
+	if sql != "test-sql" {
+		t.Errorf("unexpected sql statement: want %s got %s", testSql, sql)
+	}
+
+	if err != nil {
+		t.Error("unknown dialect should not return an error")
 	}
 }


### PR DESCRIPTION
This utilizes a scanner to build a new sql statement to linearize the process. This helps performance dramatically as we don't have to loop through the string to replace arguments multiple times. The included benchmark shows a `950.10%` performance improvement for statements with 1000 parameters. 

# Benchmark Data
Below is the data collected comparing the two implementations. 

![chart (1)](https://github.com/nullism/bqb/assets/135916/f1632e5d-fe4e-44a1-8cb2-da97dcaf395e)

Parameter Count | Performance Change
-- | --
1 | -4.66%
2 | 45.00%
10 | 256.71%
100 | 665.25%
1000 | 850.10%

The case of as single parameter is slower by 5% but larger number of substitutions are dramatically faster.
