### PR TITLE
wrapped literal bug fix

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -557,6 +557,19 @@ func TestQueryLiteralQ(t *testing.T) {
 	}
 }
 
+func TestQueryLiteralQWrapped(t *testing.T) {
+	q := New("WHERE ??| = ?", "asdf")
+	wrapped := New("?", q)
+	sql, _, err := wrapped.ToPgsql()
+	if err != nil {
+		t.Errorf("got error from ToPgsql(): %v", err)
+	}
+	want := "WHERE ?| = $1"
+	if want != sql {
+		t.Errorf("got: %q, want:%q", sql, want)
+	}
+}
+
 func TestQueryNil(t *testing.T) {
 	var q *Query
 	q2 := New("test ?", q)

--- a/utils.go
+++ b/utils.go
@@ -179,7 +179,7 @@ func makePart(text string, args ...any) QueryPart {
 			errs = append(errs, argErrs...)
 		}
 		newArgs = append(newArgs, fArgs...)
-		text = argText
+		text = strings.ReplaceAll(argText, "??", tempPh)
 	}
 
 	if err := checkParamCounts(text, originalText, newArgs); err != nil {


### PR DESCRIPTION
Summary:

When escaping a ? using ??, the query builder fails when checking the parameter counts. This is because we aren't escaping the args text.

https://github.com/nullism/bqb/issues/28